### PR TITLE
Add Linux support to IMCDelayAlarm.ps1

### DIFF
--- a/eAPI/DelayedAlarms/NonAPI/IMCDelayAlarm.ps1
+++ b/eAPI/DelayedAlarms/NonAPI/IMCDelayAlarm.ps1
@@ -124,7 +124,7 @@ if ($OsType -eq "Windows") {
 
 	$openAlarms = Invoke-SqlQuery -Query $sqlQuery
 }
-$openAlarms | Format-Table
+#$openAlarms | Format-Table
 
 if ($openAlarms) {
 	$openAlarms | ForEach-Object {

--- a/eAPI/DelayedAlarms/NonAPI/IMCDelayAlarm.ps1
+++ b/eAPI/DelayedAlarms/NonAPI/IMCDelayAlarm.ps1
@@ -5,31 +5,69 @@
 # Use pwdmgr.bat if you need to find out the password for imc_monitor, or just use another username that
 # has access to the imc_monitor DB.
 
-`
+param (
+	[string]$Database = "monitor_db",
+	[string]$DBUsername,
+	[string]$DBPassword,
+	[string]$DBHostname = "127.0.0.1",
+	[string]$EmailFrom,
+	[string]$EmailTo,
+	[string]$SMTPServer,
+	[string]$SMTPUsername,
+	[String]$SMTPPassword,
+	[Int]$SMTPPort = 25,
+	[Bool]$SMTPSSL = $false,
+	[Int]$NotificationDelay = 300
+)
+
+if (-not ($DBUsername)) {
+	Write-Error "No DBUsername is set. Exiting."
+	exit 1
+}
+
+if (-not ($SMTPServer)) {
+	Write-Error "No SMTPServer is set. Exiting."
+	exit 1
+}
+
+if ((-not ($EmailFrom)) -And (-not ($SMTPUsername))) {
+	Write-Error "No EmailFrom is set. Exiting."
+	exit 1
+}
+
+if (-not ($EmailTo)) {
+	Write-Error "No EmailTo is set. Exiting."
+	exit 1
+}
+
+if (-not ($EmailFrom) -And ($SMTPUsername)) {
+	$EmailFrom = $SMTPUsername
+}
+
 #Load SQL cmdlets
-Add-PSSnapin -Name SqlServerCmdletSnapin100 -ErrorAction SilentlyContinue
-Add-PSSnapin -Name SqlServerProviderSnapin100 -ErrorAction SilentlyContinue
+if ($OsType -eq "Windows") {
+	Add-PSSnapin -Name SqlServerCmdletSnapin100 -ErrorAction SilentlyContinue
+	Add-PSSnapin -Name SqlServerProviderSnapin100 -ErrorAction SilentlyContinue
+} else {
+	Import-Module SimplySql
+}
+
 
 #Set up DB variables. Needs testing with remote DB. Could also specify instance?
 
-$Database="monitor_db"
-$Username="imc_monitor"
-$Password="CHANGEME"	
-$Hostname="127.0.0.1"
-$AlarmsFile="C:\Temp\notifiedAlarms.csv"
+$tmpFolder = [System.IO.Path]::GetTempPath()
+$AlarmsFile=Join-Path $tmpFolder "notifiedAlarms.csv"
 $currentTime=Get-Date -UFormat %s
 # Script should be run more frequently than this - so if window is set to 5 minutes, run script at least every 4 minutes. Recommend running every minute
 # Means we won't miss any alarms due to timing variations. Recording previously notified alarms deals with potential duplicates
 # Must be given in seconds
-$notificationDelay=300
-$alarmWindow=$currentTime - $notificationDelay
-
-$emailFrom = "imc@EXAMPLE.co.nz"
-$emailTo = "ME@EXAMPLE.co.nz"
-$smtpServer = "smtp.EXAMPLE.co.nz"
+$alarmWindow=$currentTime - $NotificationDelay
 
 
-$previouslyNotifiedAlarms = Import-CSV -Path $AlarmsFile -ErrorAction SilentlyContinue
+
+if (Test-Path $AlarmsFile) {
+	$previouslyNotifiedAlarms = Import-CSV -Path $AlarmsFile -ErrorAction SilentlyContinue
+}
 
 # Set up array of Serials we've seen before. This is so we only alert once on each alarm. Ensures we capture all alarms, rather than trying to restrict time window too tightly
 $previouslyNotifiedSerials = @()
@@ -40,28 +78,53 @@ if ($previouslyNotifiedAlarms) {
 
 Function Get-LocalTime($UTCTime)
 {
-	$strCurrentTimeZone = (Get-WmiObject win32_timezone).StandardName
+	#Write-Host "$UTCTime"
+	if ($OsType -eq "Windows") {
+		$strCurrentTimeZone = (Get-WmiObject win32_timezone).StandardName
+	} else {
+		$tzPath = (readlink /etc/localtime)
+		if ($tzPath) {
+			$strCurrentTimeZone = $tzPath -replace '^.*zoneinfo/', ''
+		}
+	}
 	$TZ = [System.TimeZoneInfo]::FindSystemTimeZoneById($strCurrentTimeZone)
 	$LocalTime = [System.TimeZoneInfo]::ConvertTimeFromUtc($UTCTime, $TZ)
+	#Write-Host "$LocalTime"
 	Return $LocalTime
 }
 Function doNotify ($serial_no, $dev_name, $fault_time)
 {
-	$timeInMinutes = $notificationDelay / 60
+	$timeInMinutes = $NotificationDelay / 60
 	# Find out when the device was first marked offline
 	$readableFaultTime = New-Object -Type DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, 0
 	$readableFaultTime = $readableFaultTime.AddSeconds($fault_time)
 	$readableFaultTime = Get-LocalTime $readableFaultTime
-	$readableFaultTimeString = $readableFaultTime | Get-Date -Format F	
+	$readableFaultTimeString = $readableFaultTime | Get-Date -Format F
 	#Write-Host "Alarm number $serial_no - Device $dev_name offline for more than $timeInMinutes minutes"
 	$subject = "IMC Alarm: $dev_name offline for more than $timeInMinutes minutes"
 	# Should add code here to find out device sysLocation, Custom Views. Could then have code to work out when to notify? (e.g. Business Hours)
 	$body = "Node $dev_name has been offline since $readableFaultTimeString"
-	$smtp = new-object Net.Mail.SmtpClient($smtpServer)
-	$smtp.Send($emailFrom, $emailTo, $subject, $body)
+	$smtp = New-Object Net.Mail.SmtpClient($SMTPServer, $SMTPPort)
+	if ($SMTPUsername) {
+		$smtp.Credentials = New-Object System.Net.NetworkCredential($SMTPUsername, $SMTPPassword)
+	}
+	$smtp.EnableSsl = $SMTPSSL
+	$mail = New-Object System.Net.Mail.MailMessage($EmailFrom, $EmailTo, $subject, $body)
+	$smtp.Send($mail)
 }
 
-$openAlarms=Invoke-sqlcmd -Database $Database -Username $Username -Password $Password -Hostname $Hostname -Query "Select * from tbl_trap_data_critical WHERE fault_time > $alarmWindow AND ack_type = 0 AND fault_oid LIKE '1.3.6.1.4.1.25506.4.1.1.2.6.1';"
+
+$sqlQuery = "SELECT * FROM tbl_trap_data_critical WHERE fault_time > $alarmWindow AND ack_type = 0 AND fault_oid LIKE '1.3.6.1.4.1.25506.4.1.1.2.6.1';"
+Write-Host "$sqlQuery"
+if ($OsType -eq "Windows") {
+	$openAlarms=Invoke-sqlcmd -Database $Database -Username $DBUsername -Password $DBPassword -Hostname $DBHostname -Query $sqlQuery
+} else {
+	$connectionString = "SERVER=$Hostname;DATABASE=$Database;USER=$DBUsername;PASSWORD=$DBPassword;"
+	Open-MySqlConnection -ConnectionString $connectionString
+
+	$openAlarms = Invoke-SqlQuery -Query $sqlQuery
+}
+$openAlarms | Format-Table
 
 if ($openAlarms) {
 	$openAlarms | ForEach-Object {
@@ -73,7 +136,6 @@ if ($openAlarms) {
 		}
 	}
 }
-
 
 #Export the list of alarms we notified on - note that ErrorAction will write empty file without complaining
 $openAlarms|Export-CSV -Path $AlarmsFile -NoTypeInformation -ErrorAction SilentlyContinue


### PR DESCRIPTION
Add Linux (MySQL) support to IMCDelayAlarm. Tested on RHEL 7. You need to install PowerShell and the ``mysql-connector-odbc`` YUM package on RHEL. You can check if the MySQL DB connector is available through the ``odbcinst -q -d`` command. Handle basic error checking. Add support for bypass parameters through command line, which allows to upgrade script without manual editing on script, e.g. ``./IMCDelayAlarm.ps1 -DBUsername "root" -DBPassword "1234" -SMTPServer "mail.example.com" -SMTPPort 587 -SMTPSSL $enable -SMTPUsername "imc@example.com" -SMTPPassword "1234" -EmailTo "eduardo.mozart@example.com" -NotificationDelay 300``